### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#HybridIgniter
+# HybridIgniter
 
 A simple [HybridAuth](http://hybridauth.sourceforge.net/) - [CodeIgniter](http://ellislab.com/codeigniter) integration.
 
-##Versions
+## Versions
 - HybridAuth 2.1.2
 - CodeIgniter 2.1.3
 
-##Installation
+## Installation
 1. Drop the provided files into the CodeIgniter project
 2. Configure the providers inside the application/config/hybridauthlib.php file
 3. Modify the controller example supplied (application/controller/hauth.php) to fit your needs
 
-##How to use
+## How to use
 The only thing you need is to put as many links as you need pointing to "http://&lt;yourdomain>/index.php/hauth/login/&lt;provider>", ex.:
 
 	<a href="http://www.example.com/index.php/hauth/login/Twitter">Log in with Twitter</a><br />


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
